### PR TITLE
"nvidia/cuda" docker image creates CrashLoopBackOff error, solved

### DIFF
--- a/pod-ubuntu-gpu.yaml
+++ b/pod-ubuntu-gpu.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name:  ubuntu-gpu
-    image: nvidia/cuda
+    image: ubuntu
     command:
       - sleep
       - infinity


### PR DESCRIPTION
"nvidia/cuda" docker image doesn't start up properly on the ICCluster (CrashLoopBackOff). Regular "ubuntu" image works with CUDA as well.